### PR TITLE
Add pathing disclaimer in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ Implement the decipher release process.  The two sub-commands available here are
 The github functionality is a simple wrapper around a github SDK to create
 releases, tag commits, and upload release assets.  
 
+> Note: the github sub-command relies on the current working directory for repository information. Ensure that the final folder in the path where releaser is running matches the remote repository name. For example, for a remote repository of `releaser` the current working directory should be of the form `.../.../releaser`.
+
 ### Docker
 The docker functionality is a simple wrapper around a docker SDK to take a
 source image, tag it with major, major.minor, and major.minor.patch tags, and then to push up to dockerhub.


### PR DESCRIPTION
Releaser implicitly parses the repository name from the path which is not mentioned anywhere. This could easily lead to an accidental mis-configured environment where the command will fail. Documenting this behavior will help prevent developers not familiar with the tool from needlessly debugging their CI/CD process.